### PR TITLE
Add support for rabbitmq manager

### DIFF
--- a/.dotcloudignore
+++ b/.dotcloudignore
@@ -1,0 +1,4 @@
+.dotcloud
+.dotcloudignore
+.git
+.gitignore

--- a/dotcloud.yml
+++ b/dotcloud.yml
@@ -3,5 +3,6 @@ mq:
   buildscript: rabbitmq/builder
   ports:
    amqp: tcp
+   www: http
   systempackages:
     - erlang

--- a/rabbitmq/builder
+++ b/rabbitmq/builder
@@ -1,11 +1,34 @@
 #!/bin/sh
+# Exit on the first error
+set -e
+
+# All echo output will go to the build log. View with 'dotcloud dlogs'
+echo "START BUILDER SCRIPT"
 
 VERSION=3.0.2
 TARBALL=rabbitmq-server-generic-unix-$VERSION.tar.gz
 URL=http://www.rabbitmq.com/releases/rabbitmq-server/v$VERSION/$TARBALL
-wget $URL
-tar -C$HOME -zxf $TARBALL
-ln -s $HOME/rabbitmq_server-$VERSION $HOME/rabbitmq_server
+DESTDIR=$HOME/rabbitmq_server-$VERSION 
+SYMLINK=$HOME/rabbitmq_server
+
+if [ ! -d $DESTDIR ]
+then
+  echo "Fetching $TARBALL to create $DESTDIR"
+  wget $URL
+  tar -C$HOME -zxf $TARBALL
+  if [ -L $SYMLINK ]
+  then
+    echo "Looks like you have an old link to $SYMLINK. Removing and replacing."
+    rm $SYMLINK
+  fi
+  ln -s $DESTDIR $SYMLINK
+else
+  echo "I believe I already have $DESTDIR ..."
+  ls -l $HOME
+  echo "---------------------------------------------"
+fi
+
+# The default process will be 'run' and should be in the HOME directory
 cp $(dirname $0)/run $HOME/run
 
 PWFILE=$HOME/password

--- a/rabbitmq/run
+++ b/rabbitmq/run
@@ -1,13 +1,39 @@
 #!/bin/sh
+# Exit on the first error
+set -e
+# All echo output will go to /var/log/{servicename}.log
+echo "-------------------------"
+echo "START DOTCLOUD RUN SCRIPT"
+
 export RABBITMQ_CONFIG_FILE=$HOME/rabbitmq
+
+echo "Calculate high watermark size"
+# Set this to the value of your dotcloud scale myservice:memory=MYRAM. Leave some space for Rabbit itself.
+# You could get fancy and use dotcloud env set to set a variable and read it in from that.
+MYRAM=200
+# This gets the amount of RAM in megabytes on the whole system and then calculates the fraction equivalent to MYRAM
+HIGHWATER=`python -c "import os;sysmem=os.popen(\"free -m\").readlines()[1].split()[1];print $MYRAM/float(sysmem)"`
+echo "High water mark for RabbitMQ = $HIGHWATER"
+
+# Note PORT_AMQP and PORT_WWW come from requesting ports in dotcloud.yml with names amqp and www
+echo "Keeping the ports, password and high water mark up to date by refreshing $RABBITMQ_CONFIG_FILE"
 cat >$RABBITMQ_CONFIG_FILE.config <<EOF
 [
   {rabbit, [
     {tcp_listeners, [$PORT_AMQP]},
-    {vm_memory_high_watermark, 0.001},
+    {vm_memory_high_watermark, $HIGHWATER},
     {default_user, <<"rabbitmq">>},
     {default_pass, <<"$(cat $HOME/password)">>}
+  ]},
+  {rabbitmq_management, [
+    {http_log_dir, "/var/log/supervisor/"},
+    {listener, [{port, $PORT_WWW}]}
   ]}
 ].
 EOF
+
+echo "Enabling the management plugin"
+$HOME/rabbitmq_server/sbin/rabbitmq-plugins enable rabbitmq_management
+
+echo "Starting the server. Exec replaces this script with the server start"
 exec $HOME/rabbitmq_server/sbin/rabbitmq-server


### PR DESCRIPTION
The web interface for RabbitMQ is something dotCloud used to offer in the old `rabbitmq` service. With a few changes, your recipe can add the same feature.

This also adds a slightly more dynamic calculation of the RabbitMQ high water mark, which, unfortunately must be computed relative to all the RAM on the machine rather than just the RAM reserved for the dotCloud service container. Users should edit the `run` script to set the RAM they've reserved for the service, or possibly update it to read the value from an environment variable (which could be set via `dotcloud env set`)
