### PR TITLE
Make the config match the documentation

### DIFF
--- a/rabbitmq/run
+++ b/rabbitmq/run
@@ -10,7 +10,7 @@ export RABBITMQ_CONFIG_FILE=$HOME/rabbitmq
 echo "Calculate high watermark size"
 # Set this to the value of your dotcloud scale myservice:memory=MYRAM. Leave some space for Rabbit itself.
 # You could get fancy and use dotcloud env set to set a variable and read it in from that.
-MYRAM=${DOTCLOUD_RABBITMQ_HIGHWATERMARK:-32}
+MYRAM=${RABBITMQ_HIGHWATERMARK:-32}
 # This gets the amount of RAM in megabytes on the whole system and then calculates the fraction equivalent to MYRAM
 HIGHWATER=`python -c "import os;sysmem=os.popen(\"free -m\").readlines()[1].split()[1];print $MYRAM/float(sysmem)"`
 echo "High water mark for RabbitMQ = $HIGHWATER"


### PR DESCRIPTION
The README mentioned a certain environment variable (RABBITMQ_HIGHWATERMARK). The run script referred to a different one (DOTCLOUD_RABBITMQ_HIGHWATERMARK). DOTCLOUD_ envvars are immutable, so I had to change the run script to match the docs.
